### PR TITLE
[pt-br] Otimização da ClientCommand

### DIFF
--- a/PugMod/Util.h
+++ b/PugMod/Util.h
@@ -1,5 +1,35 @@
 #pragma once
 
+//
+// http://www.isthe.com/chongo/tech/comp/fnv/
+//
+namespace Hash
+{
+	namespace internal
+	{
+		constexpr std::uint32_t Basis{ 0x811c9dc5 };
+		constexpr std::uint32_t Prime{ 0x1000193 };
+	}
+
+	inline constexpr std::uint32_t GetConst( const std::string_view& string, const std::uint32_t value = internal::Basis ) noexcept
+	{
+		return ( string[ 0 ] == '\0' ) ? value : GetConst( &string[ 1 ], ( value ^ static_cast< std::uint32_t >( string[ 0 ] ) ) * internal::Prime );
+	}
+
+	inline std::uint32_t Get( const std::string_view& string )
+	{
+		auto ret{ internal::Basis };
+
+		for ( auto i{ 0u }; i < string.size( ); ++i )
+		{
+			ret ^= string[ i ];
+			ret *= internal::Prime;
+		}
+
+		return ret;
+	}
+}
+
 enum UTIL_PRINT_DEST_TYPE
 {
 	PRINT_NOTIFY	= 1,

--- a/PugMod/precompiled.h
+++ b/PugMod/precompiled.h
@@ -19,6 +19,7 @@
 
 // System Includes
 #include <string>
+#include <string_view>
 #include <vector>
 #include <map>
 #include <array>


### PR DESCRIPTION
Uma pequena otimização.

- Adiciona suporte a hash ( fnv1a ) em compile-time e run-time.
- Remove as dezenas de chamadas para **_stricmp**.
- A ClientCommand resolve o comando para um hash ( 4 bytes ), então apenas comparação entre inteiros é feita.

Talvez futuramente seja mais interessante evitar recursividade e criar um handler próprio para lidar com esses comandos especificos.

off: talvez seja interessante adicionar label para commits em pt-br.